### PR TITLE
Ensure OpenAPI responses use standard media type content

### DIFF
--- a/src/OpenApi/OpenApiBuilder.php
+++ b/src/OpenApi/OpenApiBuilder.php
@@ -132,30 +132,33 @@ final readonly class OpenApiBuilder
 
         $respObj = [];
         foreach ($responses as $r) {
-            $status = (string)$r['status'];
-            $desc = $r->description ?? ($r->name ?? '');
-            $contentType = $r->contentType ?? 'application/json';
+            $status      = (string) $r['status'];
+            $desc        = $r['description'] ?? ($r['name'] ?? '');
+            $contentType = $r['contentType'] ?? 'application/json';
+            $isStream    = !empty($r['stream']);
+            $mediaType   = ($isStream && $contentType === 'application/json')
+                ? 'application/x-ndjson'
+                : $contentType;
 
             $content = [];
-            if ($r['class']) {
+            if ($mediaType) {
+                $content[$mediaType] = [];
+            }
+
+            if (!empty($r['class'])) {
                 $this->registry->ensure($r['class']);
                 $schemaName = $this->schemas->schemaName($r['class']);
                 $components['schemas']->{$schemaName} ??= $this->schemas->build($r['class']);
-                $content[$contentType] = [
-                    'schema' => ['$ref' => '#/components/schemas/'.$schemaName]
-                ];
-            }
 
-            // streaming hint
-            if ($r['stream'] && $contentType === 'application/json') {
-                $contentType = 'application/x-ndjson';
+                if ($mediaType) {
+                    $content[$mediaType]['schema'] = ['$ref' => '#/components/schemas/'.$schemaName];
+                }
             }
 
             $resp = ['description' => $desc ?: Response::$statusTexts[$r['status']]];
             if ($content !== []) {
                 $resp['content'] = $content;
             }
-            $resp['content-type'] = $contentType;
 
             $respObj[$status] = $resp;
         }


### PR DESCRIPTION
## Summary
- emit OpenAPI response media types only through the `content` map, removing non-standard fields
- ensure streaming JSON responses switch to NDJSON media types and always include a media-type entry
- keep schema references when a response class is defined

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694647ca0d7483229247e3322db94e07)