### PR TITLE
Fix ResponseDTO subclass check in subscriber

### DIFF
--- a/src/EventSubscriber/ResponseDtoSubscriber.php
+++ b/src/EventSubscriber/ResponseDtoSubscriber.php
@@ -113,8 +113,8 @@ final readonly class ResponseDtoSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!is_subclass_of($mappingClass, ResponseDto::class)) {
-            throw new LogicException("DTO class '$mappingClass' must implement ResponseDto.");
+        if (!is_subclass_of($mappingClass, ResponseDTO::class)) {
+            throw new LogicException("DTO class '$mappingClass' must implement ResponseDTO.");
         }
 
         $json = $this->serializer->serialize($mappingClass::fromControllerResponse($result), 'json');


### PR DESCRIPTION
## Summary
- update ResponseDtoSubscriber to validate against the correct ResponseDTO contract
- align error message with the ResponseDTO interface name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946579e981c832296fd6b3092471a5d)